### PR TITLE
SDK Path in Linux

### DIFF
--- a/lib/titanium/environ.js
+++ b/lib/titanium/environ.js
@@ -37,7 +37,7 @@ function resolveTitaniumInstallPath()
     {
         var basedir = path.join(process.env.HOME, "/.titanium");
     }
-    else if(platform == 'osx')
+    else if(platform == 'osx' || platform == 'win32')
     {
         var basedir = "/Library/Application Support/Titanium";
     }


### PR DESCRIPTION
Hi,

I have done a simple check to know if titanium SDK is installed in linux (~/.titanium). I think you want to rewrite some parts of that file, but it's working by now. :-)
