### PR TITLE
Fixed bug where the setup script would attempt to trim() a non-string object.

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -313,7 +313,7 @@ exports.run = function (logger, config, cli) {
 			}
 			
 			Object.keys(results).forEach(function (key) {
-				config.set(key, (results[key] || '').trim());
+				config.set(key, (results[key] || '').toString().trim());
 			});
 			
 			config.save();


### PR DESCRIPTION
While running the titanium setup script, I got an error complaining about 'trimming' a boolean object. To fix this, I added a toString() call before the trim() call.

Stacktrace:

```
TypeError: Object true has no method 'trim'
    at /usr/local/lib/node_modules/titanium/lib/commands/setup.js:316:42
    at Array.forEach (native)
    at /usr/local/lib/node_modules/titanium/lib/commands/setup.js:315:25
    at /usr/local/lib/node_modules/titanium/node_modules/prompt/lib/prompt.js:316:32
    at /usr/local/lib/node_modules/titanium/node_modules/async/lib/async.js:116:25
    at assembler (/usr/local/lib/node_modules/titanium/node_modules/prompt/lib/prompt.js:313:9)
    at /usr/local/lib/node_modules/titanium/node_modules/prompt/lib/prompt.js:322:32
    at /usr/local/lib/node_modules/titanium/node_modules/prompt/lib/prompt.js:597:5
    at onLine (/usr/local/lib/node_modules/titanium/node_modules/prompt/node_modules/read/lib/read.js:111:5)
```
