### PR TITLE
[TIMOB-15842] Fixed bug with 'npm outdated' returning a version of 'missing'.

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -647,7 +647,7 @@ SetupScreens.prototype.check = function check(callback) {
 											m = parts[2].match(/\=(.+)$/);
 											results[x[0]] = {
 												latest: x[1],
-												current: m && m[1]
+												current: m && m[1] && m[1].toLowerCase() != 'missing' ? m[1] : null
 											};
 										}
 									}
@@ -1013,7 +1013,7 @@ SetupScreens.prototype.check = function check(callback) {
 				log('Java Development Kit');
 				if (r.version == null) {
 					bad('jdk', __('JDK not found!'));
-				} else if (appc.version.lt(r.version, '1.7')) {
+				} else {
 					ok('jdk', __('installed'), '(v' + r.version + ')');
 
 					if (r.executables.java) {
@@ -1036,8 +1036,6 @@ SetupScreens.prototype.check = function check(callback) {
 					} else {
 						bad('jarsigner', __('"jarsigner" executable not found; please reinstall JDK 1.6'));
 					}
-				} else {
-					bad('jdk', __('version %s is not supported; please install JDK 1.6', r.version));
 				}
 				log();
 			}(results.java));

--- a/locales/en.js
+++ b/locales/en.js
@@ -308,7 +308,6 @@
 	"\"javac\" executable not found; please reinstall JDK 1.6": "\"javac\" executable not found; please reinstall JDK 1.6",
 	"\"keytool\" executable not found; please reinstall JDK 1.6": "\"keytool\" executable not found; please reinstall JDK 1.6",
 	"\"jarsigner\" executable not found; please reinstall JDK 1.6": "\"jarsigner\" executable not found; please reinstall JDK 1.6",
-	"version %s is not supported; please install JDK 1.6": "version %s is not supported; please install JDK 1.6",
 	"compatible": "compatible",
 	"unsupported, requires an Intel® CPU": "unsupported, requires an Intel® CPU",
 	"not found; install HAXM to use Android x86 emulator": "not found; install HAXM to use Android x86 emulator",


### PR DESCRIPTION
Also removed warning if detect Java version is 1.7 or newer.
