### PR TITLE
[TIMOB-15804] Fixed bug where if the node executable is not called 'node...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+3.2.X
+-------------------
+ * Fixed bug where if the node executable is not called "node", the CLI would error because argv[0] != process.execPath. [TIMOB-15804]
+
 3.2.1
 -------------------
  * Fixed bug where npm version was not being displayed due to race condition [TIMOB-15962]

--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -71,12 +71,12 @@ require('longjohn');
 		try {
 			var config = JSON.parse(fs.readFileSync(configFilePath));
 			if (config && config.user && config.user.locale) {
-				run(config.user.locale);
+				resolveNode(config.user.locale);
 				return;
 			}
 		} catch(e) {}
 	}
-	detectLocale(run);
+	detectLocale(resolveNode);
 }());
 
 function getArg(name) {
@@ -85,6 +85,21 @@ function getArg(name) {
 		return process.argv[p + 1];
 	}
 	return null;
+}
+
+function resolveNode(locale) {
+	// we need to resolve the real node executable path such that it matches
+	// process.execPath, then the cli arg parser will know whether or not the first
+	// arg is "node" executable name.
+	//
+	// in some environments, such as Linux, the "node" executable is not called
+	// "node", so we must resolve symlinks.
+	require('node-appc').subprocess.findExecutable(process.argv[0], function (err, node) {
+		if (!err && node) {
+			process.argv[0] = fs.realpathSync(node);
+		}
+		run(locale);
+	});
 }
 
 function run(locale) {


### PR DESCRIPTION
...', the CLI would error because argv[0] != process.execPath.
