### PR TITLE
[TIMOB-16233] fixes exception with "ti help clean"

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -495,7 +495,7 @@ Context.prototype.load = function load(logger, config, cli, callback) {
 
 					} else if (isHelpCommand || (conf.platforms && cli.sdk && cli.sdk.path)) {
 						// no platform specified, load all platforms and set their options and flags
-						Object.keys(conf.platforms).forEach(function (platform) {
+						conf.platforms && Object.keys(conf.platforms).forEach(function (platform) {
 							this.platforms[platform] = new Context({
 								title: conf.platforms[platform].title || platform,
 								name: platform,


### PR DESCRIPTION
Ticket: [https://jira.appcelerator.org/browse/TIMOB-16233](https://jira.appcelerator.org/browse/TIMOB-16233)

This would also impact any other commands called with “ti help” where `conf.platforms` was not an object.
