### PR TITLE
[TIMOB-17811] `cli.sdk.platforms.iphone` is `undefined`

### DIFF
--- a/hooks/tisdk3fixes.js
+++ b/hooks/tisdk3fixes.js
@@ -72,6 +72,10 @@ exports.init = function (logger, config, cli, appc) {
 			return callback();
 		}
 
+		if (!cli.sdk.platforms.iphone) {
+			return callback();
+		}
+
 		var detectFile = path.join(cli.sdk.platforms.iphone.path, 'cli', 'lib', 'detect.js');
 		if (!fs.existsSync(detectFile)) {
 			return callback();


### PR DESCRIPTION
We check for `cli.sdk.platforms.iphone` before checking for `.path`.

This crashed a fresh **Appcelerator Studio** setup on Windows 7.
