### PR TITLE
allow the color coding to be controlled explicitly

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -178,6 +178,15 @@ function run(locale) {
 		version: pkginfo.version
 	});
 
+	// determine the default color.
+	// if we have a TTY, then use config default
+	// if we don't have a TTY and the explicit command line --colors is passed in, use this so
+	// that programs that want to include the color codes (such as a pipe) in the output, still get them
+	var defaultColor = getArg('--color');
+	if (defaultColor===undefined || defaultColor===null) {
+		defaultColor = process.stdout.isTTY ? config.get('cli.colors', true) : false;
+	}
+
 	// define the global flags
 	var conf = {
 		'flags': {
@@ -202,10 +211,9 @@ function run(locale) {
 			},
 			'colors': {
 				callback: function (value) {
-					var c = process.stdout.isTTY ? value !== false : false;
-					colors.mode = c ? 'console' : 'none';
+					colors.mode = value ? 'console' : 'none';
 					Object.keys(logger.transports).forEach(function (name) {
-						logger.transports[name].colorize = c;
+						logger.transports[name].colorize = value;
 					});
 					if (!value) {
 						// since this function is called whenever --no-color or --no-colors is set
@@ -215,7 +223,7 @@ function run(locale) {
 						cli.argv.$_.indexOf('--no-colors') == -1 && cli.argv.$_.push('--no-colors');
 					}
 				},
-				default: process.stdout.isTTY ? config.get('cli.colors', true) : false,
+				default: defaultColor,
 				desc: __('disable colors'),
 				hideDefault: true,
 				negate: true


### PR DESCRIPTION
# Summary of Change

allow the color coding to be controlled explicitly when passed in from command line even if tty is detached

this is needed for programs that want to pipe the titanium command (detached tty) but still want to pass through ansi color codes.

preserves the default behavior.

this change is needed for new unified CLI color coding.  @cb1kenobi please review.
# Verification tests

Run the following from the console to test.
## Default attached TTY

``` bash
ti 
```

should have color coding
## Default detached TTY

``` bash
ti | tee
```

should not have color coding
## Default explicit with attached TTY

``` bash
ti --color true
```

should have color coding
## Default explicit with detached TTY

``` bash
ti --color true | tee
```

should have color coding
## Default explicit with attached TTY

``` bash
ti --color false
```

should not have color coding
## Default explicit with detached TTY

``` bash
ti --color false | tee
```

should not have color coding
## Default with config merge with attached TTY

``` bash
ti --config '{cli:{colors:true}}' 
```

should have color coding
## Default with config merge with detached TTY

``` bash
ti --config '{cli:{colors:true}}' | tee
```

since not explicit on command line, should not have color coding
