### PR TITLE
[TIMOB-17605] : CLI throws an error while reading platform input value given for “ti build -p” or “ti build —platform”

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -408,6 +408,7 @@ Context.prototype.load = function load(logger, config, cli, callback) {
 
 							options = platformContext.options;
 							mix(argv, platformContext.parse(cli.argv.$_, [this.name]));
+							argv.platform = platformContext.name;
 							argv.$platform = argv.platform;
 
 							// find all platform hooks


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-17605

platform value is lost after mix. 