### PR TITLE
[TIMOB-18629] Added Node.js version check when using a Titanium SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.4.2
 -------------------
-* Fixed compatibility issues with Node 0.12
+ * Fixed compatibility issues with Node 0.12
+ * Added Node.js version check when using a Titanium SDK [TIMOB-18629]
 
 3.4.1 (11/14/14)
 -------------------

--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -398,6 +398,17 @@ function run(locale) {
 	}
 
 	if (sdk && !tooOld) {
+		// check if the sdk is compatible with our version of node
+		try {
+			if (!appc.version.satisfies(process.version.replace(/^v/, ''), sdk.packageJson.vendorDependencies.node)) {
+				logger.banner();
+				logger.error(__('Titanium SDK %s is incompatible with Node.js %s', sdk.name, process.version) + '\n');
+				logger.log(__('You will need to install Node.js %s in order to use this version of the Titanium SDK.', 'v' + appc.version.parseMax(sdk.packageJson.vendorDependencies.node)));
+				logger.log();
+				process.exit(1);
+			}
+		} catch (e) {}
+
 		// scan the sdk commands
 		cli.scanCommands(path.join(sdk.path, 'cli', 'commands'));
 		Object.keys(sdk.platforms).forEach(function (platform) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"jade": "~0.35.0",
 		"longjohn": "~0.2.2",
 		"moment": "~2.4.0",
-		"node-appc": "0.2.24",
+		"node-appc": "0.2.25",
 		"optimist": "~0.6.0",
 		"request": "~2.27.0",
 		"semver": "~2.2.1",


### PR DESCRIPTION
[TIMOB-18629] Added Node.js version check when using a Titanium SDK. Bumped node-appc version to 0.2.25.