### PR TITLE
[TIMOB-18629] Changed the Node.js check from a hard range limit to a sof...

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -90,6 +90,7 @@ logger.banner = function () {
 	if (bannerEnabled) {
 		logger.log(info.about.name.cyan.bold + ', CLI version ' + info.version + (logger.activeSdk ? ', Titanium SDK version ' + logger.activeSdk : '') + '\n' + info.about.copyright);
 		logger.log('\n' + __('Please report bugs to %s', 'http://jira.appcelerator.org/'.cyan) + '\n');
+		logger.emit('cli:logger-banner');
 		bannerWasRendered = true;
 	}
 	bannerEnabled = false;

--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -408,12 +408,18 @@ function run(locale) {
 	if (sdk && !tooOld) {
 		// check if the sdk is compatible with our version of node
 		try {
-			if (!appc.version.satisfies(process.version.replace(/^v/, ''), sdk.packageJson.vendorDependencies.node)) {
+			var supported = appc.version.satisfies(process.version.replace(/^v/, ''), sdk.packageJson.vendorDependencies.node, true);
+			if (supported === false) {
 				logger.banner();
 				logger.error(__('Titanium SDK %s is incompatible with Node.js %s', sdk.name, process.version) + '\n');
 				logger.log(__('You will need to install Node.js %s in order to use this version of the Titanium SDK.', 'v' + appc.version.parseMax(sdk.packageJson.vendorDependencies.node)));
 				logger.log();
 				process.exit(1);
+			} else if (supported === 'maybe' && !config.get('cli.hideNodejsWarning')) {
+				logger.on('cli:logger-banner', function () {
+					logger.warn(__('Support for Node.js %s has not been verified for Titanium SDK %s', process.version, sdk.name).yellow);
+					logger.warn(__('If you run into issues, try downgrading to Node.js %s', 'v' + appc.version.parseMax(sdk.packageJson.vendorDependencies.node)).yellow + '\n');
+				});
 			}
 		} catch (e) {}
 


### PR DESCRIPTION
...t high version. So if the user is running a Titanium SDK that is not tested with Node.js 0.14, it will print a warning instead of error out.