### PR TITLE
[TIMOB-18936] CLI: Titanium logging does not have colors unless passing in the --colors flaf

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -183,7 +183,7 @@ function run(locale) {
 	// if we don't have a TTY and the explicit command line --colors is passed in, use this so
 	// that programs that want to include the color codes (such as a pipe) in the output, still get them
 	var defaultColor = process.argv.indexOf('--color') !== -1;
-	if (defaultColor === undefined || defaultColor === null) {
+	if (!defaultColor) {
 		defaultColor = process.stdout.isTTY ? config.get('cli.colors', true) : false;
 	}
 


### PR DESCRIPTION
- Updated if condition when --colors is not passed as an argument


[Jira Ticket](https://jira.appcelerator.org/browse/TIMOB-18936)