### PR TITLE
TISTUD-4390 LiveView: removed 'paths.hooks' key fails to update on li…

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -363,10 +363,6 @@ Context.prototype.load = function load(logger, config, cli, callback) {
 				var argv = this.parse(cli.argv.$_, Object.keys(this.commands).length ? Object.keys(this.commands) : [this.name]),
 					isHelpCommand = cli.argv.$command == 'help';
 
-				// remove the command from the list of args
-				argv._ = cli.argv._;
-				argv._.shift();
-
 				var options = this.options,
 					finish = function () {
 						// apply missing option defaults


### PR DESCRIPTION
This is a regression caused with 4.0.0 release, and there is no need to re-fill in the options/arguments from ``cli.argv._``. Tried to test multiple commands (such as config, build, sdk, info etc) to make sure we are not causing any regression. 

TODO: Need to add unit tests for titanium commands, but pushing the fix to address 4.0.1 release.