### PR TITLE
Fix TIMOB-19126 Windows: Blue console output invisible in blue PowerShell window

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -33,6 +33,8 @@ var path = require('path'),
 		transports: [ consoul ],
 		silent: !!config.get('cli.quiet')
 	}),
+	// Windows PowerShell translates magenta to the same blue as the background. So use cyan, instead.
+	debugColor = process.platform === 'win32' && process.title.indexOf('PowerShell') >= 0 ? 'cyan' : 'magenta',
 	origLoggerLog = logger.log,
 	bannerEnabled = true,
 	bannerWasRendered = false;
@@ -185,5 +187,5 @@ logger.setLevels({
 // override colors, must be done after calling cli()
 winston.addColors({
 	trace: 'grey',
-	debug: 'magenta'
+	debug: debugColor
 });


### PR DESCRIPTION
For Windows Powershell, use cyan for debug level. Magenta and yellow don't show up.

See chalk/chalk#2 and cb1kenobi/fields#7

Also https://jira.appcelerator.org/browse/TIMOB-19126