### PR TITLE
[TIMOB-19470] No longer display latest Node.js and NPM version as it …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+5.0.3 (9/9/2015)
+-------------------
+ * No longer display latest Node.js and NPM version as it confusing may imply the Titanium CLI supports them [TIMOB-19470]
+ * Updated NPM dependencies
+
 5.0.2 (9/9/2015)
 -------------------
  * Fixed bug where 'ti setup check' was reporting the latest NPM version, not the latest stable version [TIMOB-19470]

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -798,6 +798,9 @@ SetupScreens.prototype.check = function check(callback) {
 
 			(function (r) {
 				log('Node.js');
+				ok('node', __('installed'), '(v' + r.node.current + ')');
+				ok('npm', __('installed'), '(v' + r.npm.current + ')');
+				/*
 				if (r.node.latest === null) {
 					note('node', '(v' + r.node.current + ')');
 				} else if (r.node.current == r.node.latest) {
@@ -816,6 +819,7 @@ SetupScreens.prototype.check = function check(callback) {
 				} else {
 					update('npm', __('new version v%s available!', r.npm.latest), __('(currently v%s)', r.npm.current));
 				}
+				*/
 				log();
 			}(results.nodejs));
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"mobile web",
 		"appc-client"
 	],
-	"version": "5.0.2",
+	"version": "5.0.3",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "npmjs@appcelerator.com"
@@ -35,25 +35,25 @@
 	},
 	"preferGlobal": true,
 	"dependencies": {
-		"async": "~0.2.9",
-		"colors": "~0.6.2",
-		"fields": "~0.1.22",
-		"humanize": "~0.0.9",
-		"jade": "~0.35.0",
-		"longjohn": "~0.2.2",
-		"moment": "~2.4.0",
+		"async": "1.4.2",
+		"colors": "1.1.2",
+		"fields": "0.1.24",
+		"humanize": "0.0.9",
+		"longjohn": "0.2.8",
+		"moment": "2.10.6",
 		"node-appc": "0.2.31",
-		"optimist": "~0.6.0",
-		"request": "~2.27.0",
-		"semver": "~2.2.1",
-		"sprintf": "~0.1.3",
-		"temp": "~0.6.0",
-		"winston": "0.6.x",
-		"wrench": "~1.5.4"
+		"request": "2.61.0",
+		"semver": "5.0.2",
+		"sprintf": "0.1.5",
+		"temp": "0.8.3",
+		"winston": "1.0.x",
+		"wrench": "1.5.8"
 	},
 	"devDependencies": {
+		"jade": "1.11.0",
 		"mocha": "*",
-		"should": "~1.3.0"
+		"optimist": "0.6.1",
+		"should": "7.1.0"
 	},
 	"license": "Apache-2.0",
 	"bin": {


### PR DESCRIPTION
…confusing may imply the Titanium CLI supports them. Updated NPM deps.