### PR TITLE
Extract version from URL or filename if possible, so that analytics and setting as default SDK should work

### DIFF
--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -850,13 +850,23 @@ SdkSubcommands.install = {
 		async.series([
 			function (next) {
 				if (version) {
-					var versionPath;
+					var versionPath,
+						sdkVersion,
+						m;
 					if (/^http(s)?:\/\/.+/.test(version)) {
 						// version is a URL
-						next(null, { url: version });
+						m = version.match(/mobilesdk\-([^-]+)\-(\w+)\.zip$/);
+						if (m) {
+							sdkVersion = m[1];
+						}
+						next(null, { url: version, version: sdkVersion});
 					} else if (/.+\.zip$/.test(version) && fs.existsSync(versionPath = afs.resolvePath(version)) && fs.statSync(versionPath).isFile()) {
 						// version is a file
-						next(null, { file: versionPath });
+						m = version.match(/mobilesdk\-([^-]+)\-(\w+)\.zip$/);
+						if (m) {
+							sdkVersion = m[1];
+						}
+						next(null, { file: versionPath, version: sdkVersion });
 					} else {
 						var match = version.match(/^([A-Za-z0-9_]+?)\:(.+)$/)
 						if (match) {


### PR DESCRIPTION
This hopefully should fix using the -d/--default flag when doing a `ti sdk install` with a URL or file path.