### PR TITLE
Avoid re-install of SDK from local zip

### DIFF
--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -920,16 +920,21 @@ SdkSubcommands.install = {
 				// Avoid extracting the whole SDK if we already have an SDK with the same version and timestamp installed
 				if (!cli.argv.force) {
 					// Pull out the version and os from the zipfile name!
-					var m = data.file.match(/mobilesdk\-(\d\.\d\.\d(\.\w+)?)\-(osx|win32|linux)\.zip$/);
+					var m = data.file.match(/^mobilesdk-(\d+\.\d+\.\d+(?:\.\w+)?)-(osx|win32|linux)\.zip$/);
 					if (m) {
-						// if entry doesn't exist, we get back empty string, which throws error for JSON.parse
-						var manifest = new AdmZip(data.file).readAsText('mobilesdk/' + m[3] + '/' + m[1] + '/manifest.json'),
-							json = manifest ? JSON.parse(manifest) : null,
-							version = json ? (json.name || json.version) : null;
-						// if we got the manifest and the version matches and the timestamp matches, assume it's already installed and don't re-install
-						if (version && cli.env.sdks[version] && cli.env.sdks[version].manifest.timestamp === json.timestamp) {
-							logger.log(__("Titanium SDK %s is already installed!", version.cyan) + '\n');
-							process.exit(0);
+						try {
+							// if entry doesn't exist, we get back empty string, which throws error for JSON.parse
+							var manifest = new AdmZip(data.file).readAsText('mobilesdk/' + m[3] + '/' + m[1] + '/manifest.json'),
+								json = manifest ? JSON.parse(manifest) : null,
+								version = json ? (json.name || json.version) : null;
+							// if we got the manifest and the version matches and the timestamp matches, assume it's already installed and don't re-install
+							if (version && cli.env.sdks[version] && cli.env.sdks[version].manifest.timestamp === json.timestamp) {
+								logger.log(__('Titanium SDK %s is already installed!', version.cyan) + '\n');
+								process.exit(0);
+							}
+						} catch(e) {
+							logger.error(__('Failed to extract SDK version from zipfile %s', data.file.cyan) + '\n');
+							process.exit(1);
 						}
 					}
 				}

--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -25,6 +25,7 @@ var async = require('async'),
 	path = require('path'),
 	fields = require('fields'),
 	appc = require('node-appc'),
+	AdmZip = require('adm-zip'),
 	afs = appc.fs,
 	__ = appc.i18n(__dirname).__,
 	baseUrl = process.env.APPC_ENV === 'preproduction'
@@ -916,6 +917,22 @@ SdkSubcommands.install = {
 			}
 
 			if (data.file) {
+				// Avoid extracting the whole SDK if we already have an SDK with the same version and timestamp installed
+				if (!cli.argv.force) {
+					// Pull out the version and os from the zipfile name!
+					var m = data.file.match(/mobilesdk\-(\d\.\d\.\d(\.\w+)?)\-(osx|win32|linux)\.zip$/);
+					if (m) {
+						// if entry doesn't exist, we get back empty string, which throws error for JSON.parse
+						var manifest = new AdmZip(data.file).readAsText('mobilesdk/' + m[3] + '/' + m[1] + '/manifest.json'),
+							json = manifest ? JSON.parse(manifest) : null,
+							version = json ? (json.name || json.version) : null;
+						// if we got the manifest and the version matches and the timestamp matches, assume it's already installed and don't re-install
+						if (version && cli.env.sdks[version] && cli.env.sdks[version].manifest.timestamp === json.timestamp) {
+							logger.log(__("Titanium SDK %s is already installed!", version.cyan) + '\n');
+							process.exit(0);
+						}
+					}
+				}
 				extractSDK(data.file, true, null, finish);
 			} else if (data.url) {
 				downloadSDK(data.url, function (filename) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 	},
 	"preferGlobal": true,
 	"dependencies": {
+		"adm-zip": "0.4.7",
 		"async": "2.1.2",
 		"colors": "1.1.2",
 		"fields": "0.1.24",


### PR DESCRIPTION
When installing from a local zipfile, inspect the zip's manifest.json to determine if the SDK has already been installed locally. If so, do not re-install.

This is specifically a build/test performance "fix" for doing titanium_mobile testing locally. Our "scons test" command attempts to install the locally built SDK zip before running. Even if the SDK doesn't change, it will re-extract/install. titanium CLI already skips trying to reinstall when we specify a branch explicitly or implicitly and we have the SDK installed locally. This extends that behavior to installing from local zips (note that I didn't also try to do this for remote http URLs as the SDK to install, since I assume we'd need to already download it first to check). So a developer doing local unit testing shouldn't get the penalty of re-installing SDKs if they're only iterating on the tests they're writing - and not changing/rebuilding the SDK.

cc @hansemannn 