### PR TITLE
[TIMOB-26207] Revert winston upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -399,51 +399,10 @@
 			"integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
 			"dev": true
 		},
-		"color": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-			"integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
-			"requires": {
-				"color-convert": "^0.5.0",
-				"color-string": "^0.3.0"
-			}
-		},
-		"color-convert": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-			"integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"requires": {
-				"color-name": "^1.0.0"
-			}
-		},
-		"colornames": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-			"integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
-		},
 		"colors": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
 			"integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
-		},
-		"colorspace": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-			"integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
-			"requires": {
-				"color": "0.8.x",
-				"text-hex": "0.0.x"
-			}
 		},
 		"combined-stream": {
 			"version": "1.0.6",
@@ -507,6 +466,11 @@
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
+		},
+		"cycle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -590,16 +554,6 @@
 				"wrappy": "1"
 			}
 		},
-		"diagnostics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
-			"integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
-			"requires": {
-				"colorspace": "1.0.x",
-				"enabled": "1.0.x",
-				"kuler": "0.0.x"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -623,19 +577,6 @@
 			"requires": {
 				"jsbn": "~0.1.0"
 			}
-		},
-		"enabled": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-			"integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-			"requires": {
-				"env-variable": "0.0.x"
-			}
-		},
-		"env-variable": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
-			"integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg=="
 		},
 		"error-ex": {
 			"version": "1.3.1",
@@ -1051,6 +992,11 @@
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
+		"eyes": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -1066,16 +1012,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
-		},
-		"fast-safe-stringify": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.4.tgz",
-			"integrity": "sha512-mNlGUdKOeGNleyrmgbKYtbnCr9KZkZXU7eM89JRo8vY10f7Ul1Fbj07hUBW3N4fC0xM+fmfFfa2zM7mIizhpNQ=="
-		},
-		"fecha": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
-			"integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
 		},
 		"fields": {
 			"version": "0.1.24",
@@ -1592,7 +1528,8 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
@@ -1687,11 +1624,6 @@
 			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
 			"dev": true
 		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1706,7 +1638,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1870,14 +1803,6 @@
 				"is-buffer": "^1.1.5"
 			}
 		},
-		"kuler": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-			"integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
-			"requires": {
-				"colornames": "0.0.2"
-			}
-		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -1928,18 +1853,6 @@
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
 			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-		},
-		"logform": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-1.9.0.tgz",
-			"integrity": "sha512-H1gneJlqo1dwmXq52p/X57SztuX20aWQArp69u4x7DDmCkMZgMLtBTm2LMoTz0+wu7HdkICiPj6vBbX8WJFRig==",
-			"requires": {
-				"colors": "^1.2.1",
-				"fast-safe-stringify": "^2.0.4",
-				"fecha": "^2.3.3",
-				"ms": "^2.1.1",
-				"triple-beam": "^1.2.0"
-			}
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -2108,11 +2021,6 @@
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
 			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
 		},
-		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -2210,11 +2118,6 @@
 			"requires": {
 				"wrappy": "1"
 			}
-		},
-		"one-time": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
-			"integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
 		},
 		"onetime": {
 			"version": "2.0.1",
@@ -2367,6 +2270,11 @@
 				"find-up": "^1.0.0"
 			}
 		},
+		"pkginfo": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+			"integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+		},
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -2382,7 +2290,8 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
@@ -2465,6 +2374,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -2843,6 +2753,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -2920,11 +2831,6 @@
 				"rimraf": "~2.2.6"
 			}
 		},
-		"text-hex": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-			"integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2959,11 +2865,6 @@
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
 			"dev": true
-		},
-		"triple-beam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -3035,7 +2936,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"util-extend": {
 			"version": "1.0.3",
@@ -3089,28 +2991,29 @@
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
 		},
 		"winston": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0.tgz",
-			"integrity": "sha512-7QyfOo1PM5zGL6qma6NIeQQMh71FBg/8fhkSAePqtf5YEi6t+UrPDcUuHhuuUasgso49ccvMEsmqr0GBG2qaMQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-1.1.2.tgz",
+			"integrity": "sha1-aO3Xaf951PlSjPDl2AAhqt5nSAw=",
 			"requires": {
-				"async": "^2.6.0",
-				"diagnostics": "^1.0.1",
-				"is-stream": "^1.1.0",
-				"logform": "^1.9.0",
-				"one-time": "0.0.4",
-				"readable-stream": "^2.3.6",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.2.0"
-			}
-		},
-		"winston-transport": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
-			"integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
-			"requires": {
-				"readable-stream": "^2.3.6",
-				"triple-beam": "^1.2.0"
+				"async": "~1.0.0",
+				"colors": "1.0.x",
+				"cycle": "1.0.x",
+				"eyes": "0.1.x",
+				"isstream": "0.1.x",
+				"pkginfo": "0.3.x",
+				"stack-trace": "0.0.x"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				},
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+				}
 			}
 		},
 		"wordwrap": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"semver": "5.5.0",
 		"sprintf": "0.1.5",
 		"temp": "0.8.3",
-		"winston": "3.0.0"
+		"winston": "1.1.2"
 	},
 	"devDependencies": {
 		"grunt": "^1.0.3",


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-26207

Revert the winston upgrade for now to fix the cli. The upgrade to 3 looks fairly involved as the `logger.cli();` functionality has been split out of winston core. Happy to do the upgrade if that's preferred though