### PR TITLE
Fix projectKey in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ library 'pipeline-library'
 buildNPMPackage {
 	npmVersion = '6.1.0'
 	downstream = [ '../appc-cli' ]
+	projectKey = 'TIMOB'
 }


### PR DESCRIPTION
It defaults to CLI so we need to override to TIMOB