### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -176,7 +176,7 @@ function run(locale) {
 	env.installPath = defaultInstallLocation || env.installPath;
 
 	// initialize the cli processor
-	var cli = new(require('./cli'))({
+	var cli = new (require('./cli'))({
 		config: config,
 		env: env,
 		logger: logger,

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,216 +222,10 @@
 			}
 		},
 		"@seadub/danger-plugin-eslint": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@seadub/danger-plugin-eslint/-/danger-plugin-eslint-0.3.0.tgz",
-			"integrity": "sha512-SjgB5CPmckNFm7pavqOWt/8H2g9E+aYZG5RS5LliiDkzdy0J9BsvXFNwR/74A8jbuKc9+j8rFat/cxKkfrwjZA==",
-			"dev": true,
-			"requires": {
-				"eslint": "^4.12.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				},
-				"acorn-jsx": {
-					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-					"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-					"dev": true,
-					"requires": {
-						"acorn": "^3.0.4"
-					},
-					"dependencies": {
-						"acorn": {
-							"version": "3.3.0",
-							"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-							"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-							"dev": true
-						}
-					}
-				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-					"dev": true
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"doctrine": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2"
-					}
-				},
-				"eslint": {
-					"version": "4.19.1",
-					"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-					"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-					"dev": true,
-					"requires": {
-						"ajv": "^5.3.0",
-						"babel-code-frame": "^6.22.0",
-						"chalk": "^2.1.0",
-						"concat-stream": "^1.6.0",
-						"cross-spawn": "^5.1.0",
-						"debug": "^3.1.0",
-						"doctrine": "^2.1.0",
-						"eslint-scope": "^3.7.1",
-						"eslint-visitor-keys": "^1.0.0",
-						"espree": "^3.5.4",
-						"esquery": "^1.0.0",
-						"esutils": "^2.0.2",
-						"file-entry-cache": "^2.0.0",
-						"functional-red-black-tree": "^1.0.1",
-						"glob": "^7.1.2",
-						"globals": "^11.0.1",
-						"ignore": "^3.3.3",
-						"imurmurhash": "^0.1.4",
-						"inquirer": "^3.0.6",
-						"is-resolvable": "^1.0.0",
-						"js-yaml": "^3.9.1",
-						"json-stable-stringify-without-jsonify": "^1.0.1",
-						"levn": "^0.3.0",
-						"lodash": "^4.17.4",
-						"minimatch": "^3.0.2",
-						"mkdirp": "^0.5.1",
-						"natural-compare": "^1.4.0",
-						"optionator": "^0.8.2",
-						"path-is-inside": "^1.0.2",
-						"pluralize": "^7.0.0",
-						"progress": "^2.0.0",
-						"regexpp": "^1.0.1",
-						"require-uncached": "^1.0.3",
-						"semver": "^5.3.0",
-						"strip-ansi": "^4.0.0",
-						"strip-json-comments": "~2.0.1",
-						"table": "4.0.2",
-						"text-table": "~0.2.0"
-					}
-				},
-				"eslint-scope": {
-					"version": "3.7.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-					"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"espree": {
-					"version": "3.5.4",
-					"resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-					"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-					"dev": true,
-					"requires": {
-						"acorn": "^5.5.0",
-						"acorn-jsx": "^3.0.0"
-					}
-				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-					"dev": true,
-					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"ignore": {
-					"version": "3.3.10",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-					"dev": true
-				},
-				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"regexpp": {
-					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-					"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-					"dev": true
-				},
-				"slice-ansi": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
-					}
-				},
-				"table": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-					"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-					"dev": true,
-					"requires": {
-						"ajv": "^5.2.3",
-						"ajv-keywords": "^2.1.0",
-						"chalk": "^2.1.0",
-						"lodash": "^4.17.4",
-						"slice-ansi": "1.0.0",
-						"string-width": "^2.1.1"
-					}
-				}
-			}
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@seadub/danger-plugin-eslint/-/danger-plugin-eslint-1.0.0.tgz",
+			"integrity": "sha512-ND9iIV9EFiDWK0lSDZXjmKDnKFpeiEC/vuSPL1N52LDflRyax97OB9HhPFNpQBsCeCBUzrlEjj2IsbgGPkswDw==",
+			"dev": true
 		},
 		"@seadub/danger-plugin-junit": {
 			"version": "0.0.2",
@@ -507,12 +301,6 @@
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.3.0"
 			}
-		},
-		"ajv-keywords": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-			"dev": true
 		},
 		"ansi-colors": {
 			"version": "3.2.3",
@@ -662,53 +450,6 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -869,19 +610,10 @@
 				}
 			}
 		},
-		"caller-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"dev": true,
-			"requires": {
-				"callsites": "^0.2.0"
-			}
-		},
 		"callsites": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
 			"dev": true
 		},
 		"camelcase": {
@@ -916,12 +648,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-			"dev": true
-		},
-		"circular-json": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
 			"dev": true
 		},
 		"class-utils": {
@@ -1085,18 +811,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
-			}
 		},
 		"contains-path": {
 			"version": "0.1.0",
@@ -1489,9 +1203,9 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "5.15.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.0.tgz",
-			"integrity": "sha512-xwG7SS5JLeqkiR3iOmVgtF8Y6xPdtr6AAsN6ph7Q6R/fv+3UlKYoika8SmNzmb35qdRF+RfTY35kMEdtbi+9wg==",
+			"version": "5.15.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.1.tgz",
+			"integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -1533,9 +1247,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.9.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-					"integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -1563,26 +1277,6 @@
 					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 					"dev": true
 				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-					"dev": true,
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"dev": true,
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
-					}
-				},
 				"glob": {
 					"version": "7.1.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -1602,15 +1296,6 @@
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
-				},
-				"write": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-					"dev": true,
-					"requires": {
-						"mkdirp": "^0.5.1"
-					}
 				}
 			}
 		},
@@ -2016,13 +1701,12 @@
 			}
 		},
 		"file-entry-cache": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "^2.0.1"
 			}
 		},
 		"fill-range": {
@@ -2099,26 +1783,14 @@
 			}
 		},
 		"flat-cache": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
 			"dev": true,
 			"requires": {
-				"circular-json": "^0.3.1",
-				"graceful-fs": "^4.1.2",
-				"rimraf": "~2.6.2",
-				"write": "^0.2.1"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.0.5"
-					}
-				}
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
 			}
 		},
 		"flatted": {
@@ -2624,14 +2296,6 @@
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
-				}
 			}
 		},
 		"imurmurhash": {
@@ -2941,12 +2605,6 @@
 			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
 			"dev": true
 		},
-		"is-resolvable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-			"dev": true
-		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -3016,12 +2674,6 @@
 				"istanbul-lib-coverage": "^2.0.3",
 				"semver": "^5.5.0"
 			}
-		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.12.0",
@@ -5514,14 +5166,6 @@
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
-					"dev": true
-				}
 			}
 		},
 		"parse-diff": {
@@ -5670,12 +5314,6 @@
 				"semver-compare": "^1.0.0"
 			}
 		},
-		"pluralize": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-			"dev": true
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -5686,12 +5324,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true
 		},
 		"progress": {
@@ -5762,21 +5394,6 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readline-sync": {
@@ -5910,16 +5527,6 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 			"dev": true
 		},
-		"require-uncached": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"dev": true,
-			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
-			}
-		},
 		"resolve": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -5940,9 +5547,9 @@
 			}
 		},
 		"resolve-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
 		},
 		"resolve-url": {
@@ -6012,21 +5619,6 @@
 			"resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
 			"integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
 			"dev": true
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
-			"requires": {
-				"rx-lite": "*"
-			}
 		},
 		"rxjs": {
 			"version": "6.4.0",
@@ -6463,15 +6055,6 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"stringify-object": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -6570,9 +6153,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.9.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-					"integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -6647,7 +6230,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
@@ -6769,12 +6352,6 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
-		},
-		"typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
 		},
 		"uglify-js": {
 			"version": "3.4.9",
@@ -6905,12 +6482,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"dev": true
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
 		"uuid": {
@@ -7049,9 +6620,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
 			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,77 +146,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@iamstarkov/listr-update-renderer": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
-			"integrity": "sha512-IJyxQWsYDEkf8C8QthBn5N8tIUR9V9je6j3sMIpAkonaadjbvxmRC6RAhpa3RKxndhNnU2M6iNbtJwd7usQYIA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^2.3.0",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"figures": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
-					}
-				},
-				"log-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
 		"@octokit/endpoint": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.2.tgz",
@@ -3264,12 +3193,11 @@
 			}
 		},
 		"lint-staged": {
-			"version": "8.1.4",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.4.tgz",
-			"integrity": "sha512-oFbbhB/VzN8B3i/sIdb9gMfngGArI6jIfxSn+WPdQb2Ni3GJeS6T4j5VriSbQfxfMuYoQlMHOoFt+lfcWV0HfA==",
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.5.tgz",
+			"integrity": "sha512-e5ZavfnSLcBJE1BTzRTqw6ly8OkqVyO3GL2M6teSmTBYQ/2BuueD5GIt2RPsP31u/vjKdexUyDCxSyK75q4BDA==",
 			"dev": true,
 			"requires": {
-				"@iamstarkov/listr-update-renderer": "0.4.1",
 				"chalk": "^2.3.1",
 				"commander": "^2.14.1",
 				"cosmiconfig": "^5.0.2",
@@ -3282,6 +3210,7 @@
 				"is-glob": "^4.0.0",
 				"is-windows": "^1.0.2",
 				"listr": "^0.14.2",
+				"listr-update-renderer": "^0.5.0",
 				"lodash": "^4.17.11",
 				"log-symbols": "^2.2.0",
 				"micromatch": "^3.1.8",
@@ -3799,9 +3728,9 @@
 			}
 		},
 		"mocha": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.0.0.tgz",
-			"integrity": "sha512-A7g9k3yr8oJaXn2IItFnfgjyxFc/LTe6Wwv7FczP+e8G74o9xYNSbMYmCf1ouldRojLrFcOb+z75P6Ak0GX6ug==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.0.2.tgz",
+			"integrity": "sha512-RtTJsmmToGyeTznSOMoM6TPEk1A84FQaHIciKrRqARZx+B5ccJ5tXlmJzEKGBxZdqk9UjpRsesZTUkZmR5YnuQ==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "3.2.3",
@@ -3830,9 +3759,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.1.0.tgz",
+					"integrity": "sha512-WP9f9OBL/TAbwOFBJL79FoS9UKUmnp82RWnhlwTgrAJeMq7lytHhe0Jzc6/P7Zq0+2oviXJuPlvkZalWUug9gg==",
 					"dev": true
 				},
 				"cross-spawn": {
@@ -7190,9 +7119,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.1.0.tgz",
+					"integrity": "sha512-WP9f9OBL/TAbwOFBJL79FoS9UKUmnp82RWnhlwTgrAJeMq7lytHhe0Jzc6/P7Zq0+2oviXJuPlvkZalWUug9gg==",
 					"dev": true
 				},
 				"cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -753,7 +753,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -934,7 +934,7 @@
 			"dependencies": {
 				"callsites": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
 					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
 					"dev": true
 				}
@@ -1048,7 +1048,7 @@
 				},
 				"slice-ansi": {
 					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
 					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 					"dev": true
 				},
@@ -1065,7 +1065,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -1545,7 +1545,7 @@
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
 			"requires": {
@@ -2282,7 +2282,7 @@
 		},
 		"git-config-path": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
 			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
 			"dev": true,
 			"requires": {
@@ -2909,7 +2909,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -3376,7 +3376,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -3408,7 +3408,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -6536,7 +6536,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
@@ -7116,7 +7116,7 @@
 		},
 		"yargs": {
 			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,12 +147,12 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.2.tgz",
-			"integrity": "sha512-iRx4kDYybAv9tOrHDBE6HwlgiFi8qmbZl8SHliZWtxbUFuXLZXh2yv8DxGIK9wzD9J0wLDMZneO8vNYJNUSJ9Q==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
+			"integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
 			"dev": true,
 			"requires": {
-				"deepmerge": "3.1.0",
+				"deepmerge": "3.2.0",
 				"is-plain-object": "^2.0.4",
 				"universal-user-agent": "^2.0.1",
 				"url-template": "^2.0.8"
@@ -171,9 +171,9 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.15.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.15.0.tgz",
-			"integrity": "sha512-Un+e7rgh38RtPOTe453pT/KPM/p2KZICimBmuZCd2wEo8PacDa4h6RqTPZs+f2DPazTTqdM7QU4LKlUjgiBwWw==",
+			"version": "16.16.0",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.16.0.tgz",
+			"integrity": "sha512-Q6L5OwQJrdJ188gLVmUHLKNXBoeCU0DynKPYW8iZQQoGNGws2hkP/CePVNlzzDgmjuv7o8dCrJgecvDcIHccTA==",
 			"dev": true,
 			"requires": {
 				"@octokit/request": "2.3.0",
@@ -1187,9 +1187,9 @@
 			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
 		},
 		"danger": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-7.0.12.tgz",
-			"integrity": "sha512-pew8vsBs2bitXt5upLuvfEAqvVuvzLoo/BjX7ysGI3yXQ8X7vrESo1/gGRvkA4uaDEoDq7LaBR4xhxfqxk9fog==",
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-7.0.14.tgz",
+			"integrity": "sha512-8JoWH5wge25vo0ROSplA+edy2PVk5Ttn7iR7oEq/XwWxp18lHG4B8JuYgMWqp68EcJbJlKxTWQfmANJudmJuiA==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -1209,6 +1209,7 @@
 				"lodash.includes": "^4.3.0",
 				"lodash.isobject": "^3.0.2",
 				"lodash.keys": "^4.0.8",
+				"lodash.memoize": "^4.1.2",
 				"memfs-or-file-map-to-github-branch": "^1.1.0",
 				"node-cleanup": "^2.1.2",
 				"node-fetch": "^2.3.0",
@@ -1281,9 +1282,9 @@
 			"dev": true
 		},
 		"deepmerge": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz",
-			"integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+			"integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
 			"dev": true
 		},
 		"define-properties": {
@@ -1394,9 +1395,9 @@
 			}
 		},
 		"ecdsa-sig-formatter": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-			"integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
@@ -1467,9 +1468,9 @@
 			}
 		},
 		"es6-promise": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
 			"dev": true
 		},
 		"es6-promisify": {
@@ -2396,9 +2397,9 @@
 			"dev": true
 		},
 		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
@@ -3106,12 +3107,12 @@
 			"dev": true
 		},
 		"jsonwebtoken": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
-			"integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+			"integrity": "sha512-IqEycp0znWHNA11TpYi77bVgyBO/pGESDh7Ajhas+u0ttkGkKYIIAjniL4Bw5+oVejVF+SYkaI7XKfwCCyeTuA==",
 			"dev": true,
 			"requires": {
-				"jws": "^3.1.5",
+				"jws": "^3.2.1",
 				"lodash.includes": "^4.3.0",
 				"lodash.isboolean": "^3.0.3",
 				"lodash.isinteger": "^4.0.4",
@@ -3119,7 +3120,8 @@
 				"lodash.isplainobject": "^4.0.6",
 				"lodash.isstring": "^4.0.1",
 				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1"
+				"ms": "^2.1.1",
+				"semver": "^5.6.0"
 			},
 			"dependencies": {
 				"ms": {
@@ -3142,13 +3144,13 @@
 			}
 		},
 		"jwa": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
-			"integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.3.0.tgz",
+			"integrity": "sha512-SxObIyzv9a6MYuZYaSN6DhSm9j3+qkokwvCB0/OTSV5ylPq1wUQiygZQcHT5Qlux0I5kmISx3J86TxKhuefItg==",
 			"dev": true,
 			"requires": {
 				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.10",
+				"ecdsa-sig-formatter": "1.0.11",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -3490,6 +3492,12 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
 			"integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
+			"dev": true
+		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
 		"lodash.once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -543,9 +543,9 @@
 			}
 		},
 		"acorn": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-			"integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+			"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -1446,9 +1446,9 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"doctrine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
@@ -1559,35 +1559,35 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.13.0.tgz",
-			"integrity": "sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.0.tgz",
+			"integrity": "sha512-xwG7SS5JLeqkiR3iOmVgtF8Y6xPdtr6AAsN6ph7Q6R/fv+3UlKYoika8SmNzmb35qdRF+RfTY35kMEdtbi+9wg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.5.3",
+				"ajv": "^6.9.1",
 				"chalk": "^2.1.0",
 				"cross-spawn": "^6.0.5",
 				"debug": "^4.0.1",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^4.0.0",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^4.0.2",
 				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^5.0.0",
+				"espree": "^5.0.1",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
+				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob": "^7.1.2",
 				"globals": "^11.7.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.1.0",
+				"inquirer": "^6.2.2",
 				"js-yaml": "^3.12.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.11",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
@@ -1598,14 +1598,14 @@
 				"semver": "^5.5.1",
 				"strip-ansi": "^4.0.0",
 				"strip-json-comments": "^2.0.1",
-				"table": "^5.0.2",
+				"table": "^5.2.3",
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.9.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-					"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+					"version": "6.9.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+					"integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -1633,6 +1633,26 @@
 					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 					"dev": true
 				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"dev": true,
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
+					}
+				},
 				"glob": {
 					"version": "7.1.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -1652,6 +1672,15 @@
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
+				},
+				"write": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "^0.5.1"
+					}
 				}
 			}
 		},
@@ -1781,9 +1810,9 @@
 			}
 		},
 		"eslint-scope": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
+			"integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
@@ -1803,12 +1832,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-			"integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+			"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.2",
+				"acorn": "^6.0.7",
 				"acorn-jsx": "^5.0.0",
 				"eslint-visitor-keys": "^1.0.0"
 			}
@@ -2161,6 +2190,12 @@
 					}
 				}
 			}
+		},
+		"flatted": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+			"dev": true
 		},
 		"fn-name": {
 			"version": "2.0.1",
@@ -6598,9 +6633,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.9.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-					"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+					"version": "6.9.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+					"integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"eslint-config-axway": "^4.2.2",
 		"eslint-plugin-mocha": "^5.3.0",
 		"husky": "^1.3.1",
-		"lint-staged": "^8.1.4",
+		"lint-staged": "^8.1.5",
 		"mocha": "^6.0.0",
 		"mocha-jenkins-reporter": "^0.4.1",
 		"nyc": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
 	},
 	"devDependencies": {
 		"@seadub/danger-plugin-dependencies": "0.1.0",
-		"@seadub/danger-plugin-eslint": "^0.3.0",
+		"@seadub/danger-plugin-eslint": "^1.0.0",
 		"@seadub/danger-plugin-junit": "0.0.2",
 		"danger": "^7.0.14",
-		"eslint": "^5.15.0",
+		"eslint": "^5.15.1",
 		"eslint-config-axway": "^4.2.2",
 		"eslint-plugin-mocha": "^5.3.0",
 		"husky": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@seadub/danger-plugin-dependencies": "0.1.0",
 		"@seadub/danger-plugin-eslint": "^0.3.0",
 		"@seadub/danger-plugin-junit": "0.0.2",
-		"danger": "^7.0.12",
+		"danger": "^7.0.14",
 		"eslint": "^5.15.0",
 		"eslint-config-axway": "^4.2.2",
 		"eslint-plugin-mocha": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@seadub/danger-plugin-eslint": "^0.3.0",
 		"@seadub/danger-plugin-junit": "0.0.2",
 		"danger": "^7.0.12",
-		"eslint": "^5.13.0",
+		"eslint": "^5.15.0",
 		"eslint-config-axway": "^4.2.2",
 		"eslint-plugin-mocha": "^5.3.0",
 		"husky": "^1.3.1",


### PR DESCRIPTION
This updates all the dependencies and fixes the lint error that greenkeeper has been choking on for a while now.

Closes #304, #306, #307