### PR TITLE
fix(logger): invert log levels

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -181,12 +181,12 @@ logger.cli();
 
 // override levels, must be done after calling cli()
 logger.setLevels({
-	trace: 0,
-	debug: 1,
-	info: 2,
-	warn: 3,
-	error: 4,
-	_: 5 // generic log() call
+	trace: 5,
+	debug: 4,
+	info: 3,
+	warn: 2,
+	error: 1,
+	_: 0 // generic log() call
 });
 
 // override colors, must be done after calling cli()


### PR DESCRIPTION
winston 2.x reversed the meaning of the priority levels to align with RFC524, so now 0 is the
highest priority and 5 is the lowest priority. So, we need to reorder our levels so that when
winston performs a lookup against the current log level it is respected correctly

Ref - https://github.com/winstonjs/winston/blob/master/CHANGELOG.md#breaking-changes


I took a 30 minute look into moving to winston 3.x and it seems to be a good chunk of work to maintain our existing style so I decided to just make this fix first