### PR TITLE
fix(sdk): use appc.version to sort releases to ensure correct ordering

### DIFF
--- a/lib/commands/sdk.js
+++ b/lib/commands/sdk.js
@@ -164,7 +164,7 @@ async function list(logger, config, cli) {
 	const [ releases, branches, branchBuilds ] = await Promise.all(tasks);
 
 	const sdks = cli.env.sdks;
-	const vers = Object.keys(sdks).sort().reverse();
+	const vers = appc.version.sort(Object.keys(sdks)).reverse();
 
 	let activeSDK = config.get('sdk.selected', config.get('app.sdk'));
 	if ((!activeSDK || activeSDK === 'latest') && vers.length) {
@@ -274,7 +274,7 @@ async function list(logger, config, cli) {
 			logger.log('   ' + releases.message.red);
 		} else {
 			var i = 0;
-			Array.from(releases.keys()).sort().reverse().forEach(function (r) {
+			appc.version.sort(Array.from(releases.keys())).reverse().forEach(function (r) {
 				logger.log('   ' + r.cyan + (Object.prototype.hasOwnProperty.call(sdks, r) ? ' [' + __('installed') + ']' : '') + (i++ === 0 ? ' [' + __('latest') + ']' : ''));
 			});
 			i || logger.log('   ' + __('No releases found'));
@@ -601,7 +601,7 @@ async function install(logger, config, cli) {
 	const request = await handleInstallArgs(logger, config, cli);
 
 	// record the newest sdk already installed
-	const vers = Object.keys(cli.env.sdks).filter(v => appc.version.gte(v, '3.0.0')).sort().reverse();
+	const vers = appc.version.sort(Object.keys(cli.env.sdks).filter(v => appc.version.gte(v, '3.0.0'))).reverse();
 	const newestInstalledSdk = config.get('sdk.selected', config.get('app.sdk', 'latest')) === 'latest' ? (vers.length ? vers[0] : null) : config.get('sdk.selected', config.get('app.sdk'));
 
 	const setDefault = cli.argv.default;
@@ -873,7 +873,7 @@ async function doReleases(logger, config, cli, version, osName) {
 	}
 
 	const isLatest = !version || version === 'latest';
-	const rels = Array.from(releases.keys()).sort().reverse();
+	const rels = appc.version.sort(Array.from(releases.keys())).reverse();
 
 	// if choosing latest, resolve to latest listed releases
 	if (isLatest) {
@@ -1222,7 +1222,7 @@ SdkSubcommands.uninstall = {
  */
 async function uninstall(logger, config, cli) {
 	// Gather up current state of sdks...
-	const vers = Object.keys(cli.env.sdks).sort().reverse();
+	const vers = appc.version.sort(Object.keys(cli.env.sdks)).reverse();
 	const activeSDK = config.get('sdk.selected', config.get('app.sdk', 'latest')) === 'latest' && vers.length ? vers[0] : config.get('sdk.selected', config.get('app.sdk'));
 	const activeLabel = ' [' + __('selected') + ']';
 	const maxlen = vers.reduce(function (a, b) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "titanium",
-	"version": "5.3.1",
+	"version": "5.3.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"mobile web",
 		"appc-client"
 	],
-	"version": "5.3.1",
+	"version": "5.3.2",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "npmjs@appcelerator.com"


### PR DESCRIPTION
Fixes TIMOB-28449

Note, this PR does not add this ordering to the branch listings as it's probably a little more involved as those are not even near valid versions