### PR TITLE
refactor: replace jira links with titanium_mobile repo

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -96,7 +96,7 @@ logger.banner = function () {
 	var info = appc.pkginfo.package(module, 'version', 'about');
 	if (bannerEnabled) {
 		logger.log(info.about.name.cyan.bold + ', CLI version ' + info.version + (logger.activeSdk ? ', Titanium SDK version ' + logger.activeSdk : '') + '\n' + info.about.copyright);
-		logger.log('\n' + __('Please report bugs to %s', 'http://jira.appcelerator.org/'.cyan) + '\n');
+		logger.log('\n' + __('Please report bugs to %s', 'https://github.com/appcelerator/titanium_mobile/issues'.cyan) + '\n');
 		logger.emit('cli:logger-banner');
 		bannerWasRendered = true;
 	}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		}
 	],
 	"bugs": {
-		"url": "https://jira.appcelerator.org/browse/TIMOB"
+		"url": "https://github.com/appcelerator/titanium_mobile/issues"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
I figured it made more sense to link to titanium_mobile than this repo