### PR TITLE
fix: use powershell instead of wmic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+8.0.1
+-------------------
+ * fix: On Windows call `powershell` instead of deprecated `wmic` command to
+   get the OS name and version.
+
 8.0.0 (8/1/2025)
 -------------------
  * BREAKING CHANGE: Require Node.js 20.18.1 or newer

--- a/src/util/detect.js
+++ b/src/util/detect.js
@@ -132,8 +132,10 @@ async function osInfo() {
 			}
 		}
 	} else {
-		const { stdout } = await $`wmic os get Caption,Version`;
-		[name, version] = stdout.split('\n')[1].split(/ {2,}/);
+		try {
+			const { stdout } = await $('powershell', ['-Command', 'Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version | ConvertTo-Json']);
+			({ Caption: name, Version: version } = JSON.parse(stdout));
+		} catch {}
 	}
 
 	return {


### PR DESCRIPTION
CI is failing due to:

```
'wmic' is not recognized as an internal or external command
```

This is likely to GitHub updating the `windows-latest` image which no longer includes the deprecated `wmic` command.

link: https://github.com/tidev/titanium-cli/actions/runs/17752098094/job/50448649203?pr=838