### PR TITLE
fix: Emit 'post-execute' hook for commands with async 'run()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+8.1.1
+-------------------
+ * fix: Emit `post-execute` hook for commands with async `run()`
+
 8.1.0 (9/15/2025)
 -------------------
  * fix: On Windows call `powershell` instead of deprecated `wmic` command to

--- a/src/cli.js
+++ b/src/cli.js
@@ -487,7 +487,9 @@ export class CLI {
 			});
 
 			if (r instanceof Promise) {
-				r.then(resolve).catch(reject);
+				r.then(() => this.emit('cli:post-execute', { cli: this, command: this.command }))
+					.then(() => resolve())
+					.catch(reject);
 			} else if (run.length < 4) {
 				// run doesn't expect a `callback()`
 				resolve();


### PR DESCRIPTION
If a command has a non-callback, async `run()` implementation, then the `post-execute` hook is never fired.

For example, the SDK's `cli/commands/_build.js` exports an `async function run(logger, config, cli, finished)` function. If the supplied `finished()` callback is fired, then it emits the event, but if the SDK were to remove the seemingly useless `finished()` callback, then the `post-execute` hook is never fired.

To my knowledge, nothing actually listens to the `post-execute` hook event.