### PR TITLE
ci: pin pnpm version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: latest
 
     - name: Install dependencies
       run: pnpm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "titanium",
 	"version": "8.2.0",
+	"packageManager": "pnpm@10.33.3",
 	"author": "TiDev, Inc. <npm@tidev.io>",
 	"description": "Command line interface for building Titanium SDK apps",
 	"type": "module",


### PR DESCRIPTION
## Summary
- Pin pnpm via packageManager to 10.33.3
- Let pnpm/action-setup read the packageManager field instead of installing latest

## Test Plan
- node -e "const fs = require('node:fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); if (pkg.packageManager !== 'pnpm@10.33.3') process.exit(1); console.log(pkg.packageManager);"
- git diff --check

Note: full local coverage was not rerun for this PR because the branch has a separate known ti sdk uninstall regression.