### PR TITLE
fix(sdk): Node 24 SDK extraction + restore green CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: latest
 
     - name: Install dependencies
       run: pnpm install

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"which": "6.0.1",
 		"wrap-ansi": "10.0.0",
 		"xpath": "0.0.34",
-		"yauzl": "3.3.0"
+		"yauzl": "3.4.0"
 	},
 	"devDependencies": {
 		"@reporters/github": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "titanium",
 	"version": "8.1.5",
+	"packageManager": "pnpm@10.33.3",
 	"author": "TiDev, Inc. <npm@tidev.io>",
 	"description": "Command line interface for building Titanium SDK apps",
 	"type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 0.0.34
         version: 0.0.34
       yauzl:
-        specifier: 3.3.0
-        version: 3.3.0
+        specifier: 3.4.0
+        version: 3.4.0
     devDependencies:
       '@reporters/github':
         specifier: 1.13.1
@@ -666,9 +666,6 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   c8@11.0.0:
     resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
@@ -1354,8 +1351,8 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@3.3.0:
-    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
@@ -1828,8 +1825,6 @@ snapshots:
       electron-to-chromium: 1.5.343
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  buffer-crc32@0.2.13: {}
 
   c8@11.0.0:
     dependencies:
@@ -2506,9 +2501,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yauzl@3.3.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
       pend: 1.2.0
 
   yocto-queue@0.1.0: {}

--- a/test/commands/ti-sdk.test.js
+++ b/test/commands/ti-sdk.test.js
@@ -301,7 +301,9 @@ describe('ti sdk', () => {
 			({ exitCode, stdout } = await run(['sdk', 'ls', '-bu', '--json']));
 			const json = JSON.parse(stdout);
 			assert(json.branches.branches.includes('main') || json.branches.branches.includes('master'));
-			assert(json.branches.branches.includes('12_6_X'));
+			// Assert a version-line branch exists rather than a specific one; the
+			// live branch list changes as the SDK release line advances.
+			assert(json.branches.branches.some(branch => /^\d+_\d+_X$/.test(branch)));
 			assert(json.releases[sdkName]);
 
 			assert.strictEqual(exitCode, 0);


### PR DESCRIPTION
Three fixes to get the test matrix green again across Node 20/22/**24**. The CI matrix was fully red; root causes were unrelated.

## 1. `fix(sdk)`: upgrade yauzl 3.3.0 → 3.4.0 (Node 24 SDK extraction) — user-facing bug

On **Node 24**, yauzl 3.3.0's internally-piped inflate stream produces no output for larger deflate entries — `openReadStream` returns a stream that never emits `data`/`end`. During `ti sdk install`, extraction stalls at the first big file (`lodash.js`, 544 KB): `readEntry()` is never called again, the event loop drains, and Node 24 aborts with *"Detected unsettled top-level await"*. **The SDK never finishes installing on Node 24.** Node 20/22 are unaffected (which is why only Node 24 CI failed).

yauzl 3.4.0 fixes the inflate-stream composition. Verified end-to-end: `ti sdk install 12.2.0.GA` completes on Node 24 and `lodash.js` extracts to its full 544098 bytes. Lockfile updated surgically (yauzl bump + the now-unused `buffer-crc32` removal only); `--frozen-lockfile` verified consistent.

## 2. `ci`: pin pnpm (`packageManager: pnpm@10.33.3`, drop `version: latest`)

`action-setup@v4 + version:latest` resolved **pnpm 11.x** (needs Node ≥22.13 / `node:sqlite`); the Node 20 matrix crashed during `pnpm install`. Pinning to pnpm 10.33.3 restores installs.

## 3. `test(sdk)`: stabilize the `sdk list` branch assertion

Hardcoded `branches.includes('12_6_X')` — that branch was removed from the live server (current: `11_1_X, 12_7_X, 13_0_X, 12_8_X, 13_1_X, 13_2_X`). Now asserts any `\d+_\d+_X` version-line branch.

## Notes

- Version stays `8.1.5`. Supersedes #947.
- Merge this **before** the serve command PR (#910); then merge `main` into #910.